### PR TITLE
Ação de recusar na lista de solicitações + ajustes de estilos

### DIFF
--- a/core/static/css/admin/admin.css
+++ b/core/static/css/admin/admin.css
@@ -469,6 +469,10 @@
   border: 1px solid #ccc;
   border-radius: 0.5rem;
   font-size: 0.9rem;
+  display: block;
+  width: 100%;
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
 .modal-buttons {

--- a/core/static/css/auth/cadastro_prestador.css
+++ b/core/static/css/auth/cadastro_prestador.css
@@ -138,8 +138,8 @@
 
 .icone-input {
     position: absolute;
-    top: 50%;
-    right: 1rem;
+    top: 24px; 
+    right: 10px;
     transform: translateY(-50%);
     width: 1rem; 
     height: 1rem; 

--- a/core/templates/core/admin/solicitacoes.html
+++ b/core/templates/core/admin/solicitacoes.html
@@ -46,21 +46,37 @@
     </div>
 </section>
 
+<form id="form-recusar" method="post" style="display: none;">
+    {% csrf_token %}
+    <input type="hidden" name="acao" value="rejeitar">
+</form>
+
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         const lista = document.getElementById('lista-solicitacoes');
+        const formRecusar = document.getElementById('form-recusar');
 
         if (lista) {
             lista.addEventListener('click', function(e) {
                 const botao = e.target.closest('button');
+                if (!botao) return;
                 
-                if (botao && botao.textContent.trim() === 'Ver detalhes') {
+                const wrapper = botao.closest('.card-link-wrapper');
+                if (!wrapper || !wrapper.dataset.url) return;
+
+                const textoBotao = botao.textContent.trim();
+
+                if (textoBotao === 'Ver detalhes') {
+                    e.preventDefault();
+                    window.location.href = wrapper.dataset.url;
+                }
+
+                else if (textoBotao === 'Recusar') {
                     e.preventDefault();
                     
-                    const wrapper = botao.closest('.card-link-wrapper');
-                    
-                    if (wrapper && wrapper.dataset.url) {
-                        window.location.href = wrapper.dataset.url;
+                    if (confirm('Tem certeza que deseja recusar esta solicitação?')) {
+                        formRecusar.action = wrapper.dataset.url;
+                        formRecusar.submit();
                     }
                 }
             });

--- a/core/templates/core/prestador/perfil.html
+++ b/core/templates/core/prestador/perfil.html
@@ -9,16 +9,6 @@
 {% block content %}
 <main class="profile-page-content">
 
-  {% if messages %}
-    <div style="width: 100%; max-width: 600px; margin-bottom: 1rem;">
-      {% for message in messages %}
-        <div style="padding: 10px; border-radius: 5px; margin-bottom: 5px; background-color: {% if message.tags == 'success' %}#d4edda{% else %}#f8d7da{% endif %}; color: {% if message.tags == 'success' %}#155724{% else %}#721c24{% endif %};">
-          {{ message }}
-        </div>
-      {% endfor %}
-    </div>
-  {% endif %}
-
   <div class="profile-card">
     <!-- Cabeçalho -->
     <header class="profile-header">


### PR DESCRIPTION
### **O que foi feito:**
- Adicionado um formulário invisível no template de solicitacoes para permitir o envio de requisições POST (ação de recusar) diretamente da lista, sem precisar entrar na tela de detalhes.
- Removi o bloco de messages para evitar duplicidade de notificações.
- Pequeno ajuste no modal para quebrar a linha e respeitar os elementos.