### PR TITLE
feat: Gestão de Agendamentos pelo Prestador

### DIFF
--- a/core/templates/core/prestador/home.html
+++ b/core/templates/core/prestador/home.html
@@ -41,14 +41,36 @@
             </div>
         </div>
 
-        <div class="results-list">
+        <div class="results-list" id="lista-agendamentos">
             {% for agendamento in agendamentos %}
-                {% card_wonder 
-                    title=agendamento.servico.nome 
-                    img_url=agendamento.cliente.usuario.foto_perfil.url|default:"img/icones/icon_footer/user.svg" 
-                    subtitle=agendamento.cliente.usuario.first_name 
-                    buttons_preset="finish_cancel" 
-                %}
+                
+                <div class="agendamento-card-wrapper" 
+                     data-id="{{ agendamento.id }}" 
+                     data-cliente="{{ agendamento.cliente.usuario.first_name }}">
+                    
+                    {% with hora=agendamento.data_hora_inicio|date:"H:i" %}
+                        
+                        {% if agendamento.cliente.usuario.foto_perfil %}
+                            
+                            {% if agendamento.status == 'AGENDADO' %}
+                                {% card_wonder title=agendamento.servico.nome img_url=agendamento.cliente.usuario.foto_perfil.url subtitle=agendamento.cliente.usuario.first_name time_value=hora buttons_preset="confirm_reject" %}
+                            {% else %}
+                                {% card_wonder title=agendamento.servico.nome img_url=agendamento.cliente.usuario.foto_perfil.url subtitle=agendamento.cliente.usuario.first_name time_value=hora buttons_preset="finish_cancel" %}
+                            {% endif %}
+
+                        {% else %}
+                            
+                            {% if agendamento.status == 'AGENDADO' %}
+                                {% card_wonder title=agendamento.servico.nome img_url="img/icones/icon_footer/user.svg" subtitle=agendamento.cliente.usuario.first_name time_value=hora buttons_preset="confirm_reject" %}
+                            {% else %}
+                                {% card_wonder title=agendamento.servico.nome img_url="img/icones/icon_footer/user.svg" subtitle=agendamento.cliente.usuario.first_name time_value=hora buttons_preset="finish_cancel" %}
+                            {% endif %}
+
+                        {% endif %}
+                        
+                    {% endwith %}
+                </div>
+
             {% empty %}
                 <div style="text-align: center; margin-top: 2rem; color: #999;">
                     <p>Não há agendamentos em aberto nesta data.</p>
@@ -71,11 +93,26 @@
     
 </div>
 
-<!-- Calaendário Flatpickr JS -->
+<form id="form-confirmar" method="POST" style="display: none;">
+    {% csrf_token %}
+</form>
+
+<form id="form-finalizar" method="POST" style="display: none;">
+    {% csrf_token %}
+</form>
+
+<form id="form-cancelar" method="POST" style="display: none;">
+    {% csrf_token %}
+    <input type="hidden" name="motivo_cancelamento" value="Cancelado pelo prestador via painel.">
+</form>
+
 <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 <script src="https://npmcdn.com/flatpickr/dist/l10n/pt.js"></script>
 <script>
     document.addEventListener('DOMContentLoaded', function() {
+        
+        const dataAtual = "{{ data_escolhida|date:'Y-m-d' }}";
+
         const btnCalendario = document.getElementById('btn-abrir-calendario');
         
         const fp = flatpickr("#agenda-input", {
@@ -91,9 +128,57 @@
             }
         });
 
-        btnCalendario.addEventListener('click', function() {
-            fp.toggle();
-        });
+        if(btnCalendario) {
+            btnCalendario.addEventListener('click', function() {
+                fp.toggle();
+            });
+        }
+
+        const lista = document.getElementById('lista-agendamentos');
+        const formConfirmar = document.getElementById('form-confirmar');
+        const formFinalizar = document.getElementById('form-finalizar');
+        const formCancelar = document.getElementById('form-cancelar');
+
+        if (lista) {
+            lista.addEventListener('click', function(e) {
+                const botao = e.target.closest('button');
+                if (!botao) return;
+
+                const wrapper = botao.closest('.agendamento-card-wrapper');
+                if (!wrapper) return;
+
+                const id = wrapper.dataset.id;
+                const cliente = wrapper.dataset.cliente;
+                const textoBotao = botao.textContent.trim();
+                const queryData = `?data=${dataAtual}`;
+
+                if (textoBotao === 'Confirmar') {
+                    formConfirmar.action = `/prestador/agendamentos/confirmar/${id}/${queryData}`;
+                    formConfirmar.submit();
+                }
+
+                else if (textoBotao === 'Recusar') {
+                    if (confirm(`Deseja recusar o agendamento de ${cliente}?`)) {
+                        formCancelar.action = `/prestador/agendamentos/cancelar/${id}/${queryData}`;
+                        formCancelar.submit();
+                    }
+                }
+
+                else if (textoBotao === 'Finalizar') {
+                    if (confirm(`Deseja finalizar o serviço para ${cliente}?`)) {
+                        formFinalizar.action = `/prestador/agendamentos/finalizar/${id}/${queryData}`;
+                        formFinalizar.submit();
+                    }
+                }
+                
+                else if (textoBotao === 'Cancelar') {
+                    if (confirm(`Tem certeza que deseja cancelar o agendamento de ${cliente}?`)) {
+                        formCancelar.action = `/prestador/agendamentos/cancelar/${id}/${queryData}`;
+                        formCancelar.submit();
+                    }
+                }
+            });
+        }
     });
 </script>
 {% endblock %}

--- a/core/templatetags/card_wonder.py
+++ b/core/templatetags/card_wonder.py
@@ -47,6 +47,10 @@ def card_wonder(
             {'text': 'Ver detalhes', 'color': 'blue'},
             {'text': 'Recusar', 'color': 'red'},
         ],
+        'confirm_reject': [
+            {'text': 'Confirmar', 'color': 'blue'},
+            {'text': 'Recusar', 'color': 'red'},
+        ],
     }
 
     btn_finish = button_presets.get(buttons_preset)

--- a/core/urls.py
+++ b/core/urls.py
@@ -38,6 +38,7 @@ urlpatterns = [
     path('prestador/perfil', prestador_views.prestador_perfil_view, name='prestador-perfil'),
     path('prestador/home/', prestador_views.prestador_home_view, name='prestador-home'),
     path('prestador/agendamentos/', prestador_views.prestador_home_view, name='prestador-agendamentos'),
+    path('prestador/agendamentos/confirmar/<int:agendamento_id>/', prestador_views.confirmar_agendamento_view, name='confirmar-agendamento'), # NOVA
     path('prestador/agendamentos/finalizar/<int:agendamento_id>/', prestador_views.finalizar_agendamento_view, name='finalizar-agendamento'),
     path('prestador/agendamentos/cancelar/<int:agendamento_id>/', prestador_views.cancelar_agendamento_view, name='cancelar-agendamento'),
  

--- a/core/views/cliente_views.py
+++ b/core/views/cliente_views.py
@@ -231,7 +231,7 @@ def cliente_estabelecimento_horarios_view(request: HttpRequest) -> HttpResponse:
     duracao_total = sum([s.duracao_minutos for s in servicos_objetos])
 
     data_get = request.GET.get('data')
-    hoje = timezone.now().date()
+    hoje = timezone.localtime(timezone.now()).date()
     
     try:
         data_selecionada = datetime.strptime(data_get, '%Y-%m-%d').date() if data_get else hoje

--- a/core/views/prestador_views.py
+++ b/core/views/prestador_views.py
@@ -18,9 +18,9 @@ def prestador_home_view(request: HttpRequest) -> HttpResponse:
         try:
             data_escolhida = timezone.datetime.strptime(data_str, "%Y-%m-%d").date()
         except ValueError:
-            data_escolhida = timezone.now().date()
+            data_escolhida = timezone.localtime(timezone.now()).date()
     else:
-        data_escolhida = timezone.now().date()
+        data_escolhida = timezone.localtime(timezone.now()).date()
 
     agendamentos = Agendamento.objects.filter(
         prestador=prestador,
@@ -42,6 +42,18 @@ def finalizar_agendamento_view(request: HttpRequest, agendamento_id: int) -> Htt
     messages.success(request, 'Agendamento finalizado com sucesso!')
     return redirect('prestador-home')
 
+@prestador_required
+def confirmar_agendamento_view(request: HttpRequest, agendamento_id: int) -> HttpResponse:
+    agendamento = get_object_or_404(Agendamento, id=agendamento_id, prestador=request.user.perfil_prestador)
+    
+    if agendamento.status == Agendamento.StatusAgendamento.AGENDADO:
+        agendamento.status = Agendamento.StatusAgendamento.CONFIRMADO
+        agendamento.save()
+        messages.success(request, 'Agendamento confirmado com sucesso!')
+    else:
+        messages.warning(request, 'Este agendamento não está pendente.')
+        
+    return redirect('prestador-home')
 
 @prestador_required
 def cancelar_agendamento_view(request: HttpRequest, agendamento_id: int) -> HttpResponse:


### PR DESCRIPTION
### Alterações Realizadas:

- Adicionados botões de ação "Confirmar" e "Recusar" na tela inicial do prestador para agendamentos com status agendado.
- Implementada view confirmar_agendamento_view para alterar o status para confirmado.

- Lógica condicional no template para exibir os botões corretos dependendo do status do agendamento (se confirmado, exibe "Finalizar/Cancelar").

- Atualizada a lógica de datas nas views para garantir que o dia atual respeite o fuso horário configurado (America/Sao_Paulo) e não o UTC do servidor, evitando o bug de pular para o dia seguinte após as 21h.

- Adicionado novo preset na tag card_wonder.
- Correção no template home.html para evitar erros de renderização quando o cliente não possui foto de perfil.